### PR TITLE
Allow correct escaping of preview text for element

### DIFF
--- a/app/views/alchemy/admin/elements/update.js.erb
+++ b/app/views/alchemy/admin/elements/update.js.erb
@@ -6,7 +6,7 @@
 <%- if @element_validated -%>
 
   $errors.hide();
-  $el.trigger('SaveElement.Alchemy', {previewText: '<%= sanitize(@element.preview_text) %>'});
+  $el.trigger('SaveElement.Alchemy', {previewText: '<%== j sanitize(@element.preview_text) %>'});
   Alchemy.growl('<%= Alchemy.t(:element_saved) %>');
   Alchemy.PreviewWindow.refresh(function() {
     Alchemy.ElementEditors.selectElementInPreview(<%= @element.id %>);


### PR DESCRIPTION
- When adding a single quote to an essence title the save button never completes
- This is due to the previewText not properly being escaped
